### PR TITLE
ARE-8141: Point url to our mirror

### DIFF
--- a/ZMQ/url
+++ b/ZMQ/url
@@ -1,1 +1,1 @@
-https://github.com/JuliaInterop/ZMQ.jl.git
+https://github.com/analyzere/ZMQ.jl.git


### PR DESCRIPTION
Going to try to see if we can patch ZMQ.jl to use a locally built version of libzmq